### PR TITLE
Workaround for non-browser environment support + Fix for "lacks return-type annotation" error

### DIFF
--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -174,8 +174,8 @@ declare namespace SendBird {
     getSubscribedCustomTypeTotalUnreadMessageCount(): number;
     getSubscribedCustomTypeUnreadMessageCount(customType: string): number;
 
-    getMyGroupChannelChangeLogsByToken(token: string, customTypes: Array<string>, callback:getGroupChannelChangeLogsHandler);
-    getMyGroupChannelChangeLogsByTimestamp(ts: number, customTypes: Array<string>, callback:getGroupChannelChangeLogsHandler);
+    getMyGroupChannelChangeLogsByToken(token: string, customTypes: Array<string>, callback: getGroupChannelChangeLogsHandler): void;
+    getMyGroupChannelChangeLogsByTimestamp(ts: number, customTypes: Array<string>, callback: getGroupChannelChangeLogsHandler): void;
   }
 
   interface Options {
@@ -770,7 +770,7 @@ declare namespace SendBird {
       progressHandler: fileUploadprogressHandler,
       callback: messageCallback
     ): FileMessage; // DEPRECATED
-    
+
     sendFileMessages(fileMessageParamsList: Array<FileMessageParams>, callbackObject: fileMessagesCallbackObject): Array<FileMessage>;
 
     /** UserMessage  */

--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -7,6 +7,10 @@
 export = SendBird;
 export as namespace SendBird;
 
+// Workaround for non-browser environment support.
+interface File {}
+interface ProgressEvent {}
+
 declare const SendBird: SendBirdStatic;
 
 interface SendBirdStatic {


### PR DESCRIPTION
Fixes these errors (https://github.com/smilefam/SendBird-SDK-JavaScript/issues/85):

<img width="1230" alt="2018-12-11 23 31 04" src="https://user-images.githubusercontent.com/357153/49834519-daa87a00-fd9c-11e8-8227-f398a7a88df5.png">

.. and allows to compile with TypeScript on Node.js.