### PR TITLE
Update types to allow discriminated union

### DIFF
--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -284,7 +284,6 @@ declare namespace SendBird {
     channelUrl: string;
     channelType: string;
     messageId: number;
-    messageType: string;
     data: string;
     customType: string;
     metaArrays: Array<MessageMetaArray>;
@@ -310,6 +309,7 @@ declare namespace SendBird {
   }
 
   interface AdminMessage extends BaseMessageInstance {
+    messageType: "admin";
     message: string;
     translations: Object;
   }
@@ -337,6 +337,7 @@ declare namespace SendBird {
     pushNotificationDeliveryOption: "default" | "suppress";
   }
   interface UserMessage extends BaseMessageInstance {
+    messageType: "user";
     message: string;
     sender: Sender;
     reqId: string;
@@ -367,6 +368,7 @@ declare namespace SendBird {
     pushNotificationDeliveryOption: "default" | "suppress";
   }
   interface FileMessage extends BaseMessageInstance {
+    messageType: "file";
     sender: Sender;
     reqId: string;
     url: string;


### PR DESCRIPTION
In the typescript typings I have updated the "messageType" value to string literals and moved into the specific sub type of message. This will give the typescript compiler sufficient information to discriminate the union of the three message types preventing the need for casts, simplifying the workflow and reducing confusion.