### PR TITLE
Add return type for `SendBirdStatic.setLogLevel`

### DIFF
--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -17,7 +17,7 @@ interface SendBirdStatic {
   LogLevel: SendBird.LogLevel;
 
   getLogLevel(): typeof SendBird.LogLevel[keyof typeof SendBird.LogLevel];
-  setLogLevel(logLevel: typeof SendBird.LogLevel[keyof typeof SendBird.LogLevel]);
+  setLogLevel(logLevel: typeof SendBird.LogLevel[keyof typeof SendBird.LogLevel]): void;
 }
 
 declare namespace SendBird {


### PR DESCRIPTION
Typescript compiler emits an error for  lack of return type for `setLogLevel`