### PR TITLE
Fix: Change type string to Array<string> in `PreviousMessageListQuery`

### DIFF
--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -1510,7 +1510,7 @@ declare namespace SendBird {
      * @deprecated since version v3.0.142, please use {@link customTypesFilter} instead
      */
     customTypeFilter: string;
-    customTypesFilter: string;
+    customTypesFilter: Array<string>;
     senderUserIdsFilter: Array<string>;
     includeMetaArray: boolean;
     /**


### PR DESCRIPTION
`PreviousMessageListQuery`'s `customTypesFilter` is `string` but it emit error `invalid paramter`.
After changing `SendBird.d.ts` locally(node_modules) `string` to `Array<string>` and assign `Array<string>` like
```js
listQuery.customTypesFilter = ['customType1', 'customType2'];
```
and it works well.

Please check it.