### PR TITLE
Fix for the userCallback type - error and user positions were reversed.

### DIFF
--- a/SendBird.d.ts
+++ b/SendBird.d.ts
@@ -26,7 +26,7 @@ declare namespace SendBird {
     message: string;
   }
 
-  type userCallback = (user: User, error: SendBirdError) => void;
+  type userCallback = (error: SendBirdError, user: User) => void;
   type pushSettingCallback = (response: string, error: SendBirdError) => void;
 
   type getFriendChangeLogs = {


### PR DESCRIPTION
As the title states, I noticed the type signature for `userCallback` is incorrect - namely, the order of `user` and `error` are reversed. This is of course a pain in that TypeScript complains because it thinks the user object is an error object, for example in the callbacks to `sendbird.connect` or `sendbird.updateCurrentUserInfo`. This pull request would resolve that typing issue.